### PR TITLE
Lower initialSampleSize to 1

### DIFF
--- a/src/Benchmark.elm
+++ b/src/Benchmark.elm
@@ -230,7 +230,7 @@ findSampleSize : Operation -> Task Error Int
 findSampleSize operation =
     let
         initialSampleSize =
-            100
+            1
 
         minimumRuntime =
             100 * Time.millisecond


### PR DESCRIPTION
Benchmarking something where you can only get 20 or 30 samples/sec (for example, creating a dict of 10K entries), with quite a few benchmarks in a group, will lock up IE browsers for > 240 seconds. This prevents using elm-benchmark in an automated way on e.g. BrowserStack, which will just kill the session if the browser stays unresponsive for that long.

For most things, having the `initialSampleSize` as 1 rather than 100 will only mean 2 extra runs of `findSampleSize`, which seems totally acceptable to me.

Additionally, it's a non-API-breaking change vs the alternative - allowing the initial sample size to be set. That feels like overkill as *most* of the time, you wouldn't want it to be anything other than 100, anyway.

Thoughts?