### PR TITLE
smooth out sample sizes by changing the way they're calculated

### DIFF
--- a/src/Benchmark/LowLevel.elm
+++ b/src/Benchmark/LowLevel.elm
@@ -103,14 +103,17 @@ findSampleSize benchmark =
             1
 
         minimumRuntime =
-            25 * Time.millisecond
+            50 * Time.millisecond
 
-        -- increase the sample size by powers of 10 until we meet the minimum runtime
         resample : Int -> Time -> Task Error Int
         resample size total =
             if total < minimumRuntime then
-                sample (size * 10) benchmark
-                    |> Task.andThen (resample (size * 10))
+                let
+                    new =
+                        ceiling <| toFloat size * 1.618103
+                in
+                sample new benchmark
+                    |> Task.andThen (resample new)
             else
                 Task.succeed size
     in


### PR DESCRIPTION
A while back @zwilias did some work spelunking into the V8 compiler to figure out why sometimes benchmarks have really huge sample sizes. (#11, and thanks again!)

Turns out that the runtime and our sample determination code were interacting badly. The runtime would slow down the code for JIT profiling, and `findSampleSize` which would respond *really* aggresively by doing an order of magnitude more work every time.

So it turns out that the JIT isn't so much at fault here as the aggressive `findSampleSize`. The solution was to make the sample size increase more gradually (but it's still compounding, so it finishes fairly fast.) I changed it to increase according to the golden ratio, because why not?

As a knock-on effect of this change, I was able to move the minimum runtime around so that the UI is more responsive while still gathering accurate data. Win-win!

Resolves #11