### PR TITLE
re-simplify Benchmark.LowLevel

### DIFF
--- a/src/Benchmark/Benchmark.elm
+++ b/src/Benchmark/Benchmark.elm
@@ -3,11 +3,11 @@ module Benchmark.Benchmark exposing (..)
 {-| hey, don't publish me please!
 -}
 
-import Benchmark.LowLevel as LowLevel
+import Benchmark.LowLevel as LowLevel exposing (Operation)
 import Benchmark.Status exposing (Status)
 
 
 type Benchmark
-    = Single LowLevel.Benchmark Status
-    | Series String (List ( LowLevel.Benchmark, Status ))
+    = Single String Operation Status
+    | Series String (List ( String, Operation, Status ))
     | Group String (List Benchmark)

--- a/src/Benchmark/Reporting.elm
+++ b/src/Benchmark/Reporting.elm
@@ -155,12 +155,12 @@ compareOperationsPerSecond a b =
 fromBenchmark : Benchmark -> Report
 fromBenchmark internal =
     case internal of
-        Benchmark.Single benchmark status ->
-            Single (LowLevel.name benchmark) status
+        Benchmark.Single name _ status ->
+            Single name status
 
         Benchmark.Series name benchmarks ->
             benchmarks
-                |> List.map (Tuple.mapFirst LowLevel.name)
+                |> List.map (\( name, _, status ) -> ( name, status ))
                 |> Series name
 
         Benchmark.Group name benchmarks ->


### PR DESCRIPTION
It got a name. It doesn't need a name. Now it's just operations again and `Benchmark` takes care of naming things.