### PR TITLE
Adjust report layout to accommodate a long list of benchmarks

### DIFF
--- a/src/Benchmark/Runner/App.elm
+++ b/src/Benchmark/Runner/App.elm
@@ -79,19 +79,18 @@ view model =
                     |> Element.mapAll identity InProgressClass identity
     in
     Element.viewport (Style.styleSheet styles) <|
-        Element.el Page
+        Element.row Page
             [ width fill
-            , height fill
+            , minHeight fill
+            , center
+            , verticalCenter
             ]
-        <|
-            Element.el Wrapper
-                [ center
-                , verticalCenter
-                , maxWidth (px 800)
+            [ Element.el Wrapper
+                [ maxWidth (px 800)
                 , padding 60
                 ]
-            <|
                 body
+            ]
 
 
 


### PR DESCRIPTION
This should fix #37. I used the example from [this Ellie](https://ellie-app.com/8rVXQ3tPVa1/0) to verify that a longer list displays as expected (and that a shorter list is still vertically centered).