### PR TITLE
Cli#38 bootstrap elm benchmark

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@ documentation.json
 
 # tooling
 elm-ops-tooling
+
+# cli related files
+node_modules
+elm-benchmark-*.tgz

--- a/Makefile
+++ b/Makefile
@@ -23,3 +23,7 @@ examples/%.html: examples/% examples/elm-stuff ${ELM_FILES}
 clean:
 	find . -name 'elm-stuff' -type d | xargs rm -rf
 	find . -name '*.html' -type f -delete
+
+.PHONY: publish_cli
+publish_cli:
+	npm publish $(shell npm pack --cwd cli)

--- a/cli/.gitignore
+++ b/cli/.gitignore
@@ -1,0 +1,5 @@
+benchmarks/
+elm-package.json
+docs/
+node_modules/
+elm-benchmark-*.tgz

--- a/cli/.gitignore
+++ b/cli/.gitignore
@@ -1,5 +1,0 @@
-benchmarks/
-elm-package.json
-docs/
-node_modules/
-elm-benchmark-*.tgz

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,0 +1,42 @@
+# elm-benchmark
+
+A CLI tool to manage [BrianHicks/elm-benchmark][eb] in your Elm project.
+
+[eb]: https://github.com/BrianHicks/elm-benchmark
+
+# Install
+
+```sh
+$ npm install elm-benchmark -D
+```
+
+You may install globally (with `-g` option) if you want to.
+
+# Usage
+
+```sh
+$ node_modules/.bin/elm-benchmark init    # Generates benchmarks/ directory with sample benchmark app
+$ node_modules/.bin/elm-benchmark compile # Default output file is docs/index.html
+$ open docs/index.html
+
+$ node_modules/.bin/elm-benchmark install # Just installs Elm packages in benchmarks/elm-package.json
+```
+
+Re-running `init` will not overwrite existing `benchmarks/elm-package.json` and `benchmarks/Benchmarks.elm`.
+
+Uses `node_modules/.bin/elm-*` binaries if they exist, otherwise look for globally installed Elm binaries.
+
+# Directory Structure
+
+```
+(Your Elm project directory)
+|- elm-package.json # Required
+|- elm-stuff/
+|- src/
+|- docs/
+|  \- index.html # Default compile target of benchmark app
+\- benchmarks/
+   |- elm-package.json # Generated. Will have ['../src', '.'] as `source-directories`
+   |- Benchmarks.json  # Generated
+   \- elm-stuff/
+```

--- a/cli/bin/elm-benchmark
+++ b/cli/bin/elm-benchmark
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+require('../elm-benchmark.js')

--- a/cli/elm-benchmark.js
+++ b/cli/elm-benchmark.js
@@ -1,0 +1,200 @@
+const fs = require('fs')
+const path = require('path')
+const proc = require('child_process')
+const which = require('which')
+
+const elmPackageJson = 'elm-package.json'
+const benchDir = path.resolve('benchmarks')
+
+const ensureBenchDir = () => {
+  try {
+    fs.mkdirSync(benchDir)
+    console.log(`Created: ${benchDir}`)
+  } catch (e) {
+    if (!e.message.startsWith('EEXIST')) {
+      throw e
+    }
+  }
+}
+
+const prepareElmPackageJson = () => {
+  var rootJson = {}
+  try {
+    rootJson = JSON.parse(fs.readFileSync(path.resolve(elmPackageJson)))
+  } catch(e) {
+    if (e.message.startsWith('ENOENT')) {
+      console.error(`Missing ${elmPackageJson} file.`)
+      process.exit(1)
+    } else {
+      throw e
+    }
+  }
+  const newSourceDirs =
+    rootJson['source-directories']
+      .map(dir => path.join('..', dir))
+      .concat('.')
+  const benchJson = Object.assign(rootJson, {
+    'summary': 'Benchmark for the parent project',
+    'dependencies': Object.assign(rootJson.dependencies, {
+      'BrianHicks/elm-benchmark': '2.0.1 <= v < 3.0.0'
+    }),
+    'exposed-modules': [],
+    'source-directories': newSourceDirs
+  })
+  const target = path.join(benchDir, elmPackageJson)
+  const contents = JSON.stringify(benchJson, null, 4) + '\n'
+  ensureFile(target, contents)
+}
+
+const ensureFile = (target, contents) => {
+  try {
+    fs.writeFileSync(target, contents, {flag: 'wx'})
+    console.log(`Created: ${target}`)
+  } catch(e) {
+    if (!e.message.startsWith('EEXIST')) {
+      throw e
+    }
+  }
+}
+
+const elmBinPath = (bin) => {
+  var elmBin = bin
+  const localElmBin = path.resolve(path.join('node_modules', '.bin', elmBin))
+  if (fs.existsSync(localElmBin)) {
+    elmBin = localElmBin
+  } else {
+    try {
+      which.sync(elmBin)
+    } catch(e) {
+      if (e.message.startsWith('not found')) {
+        console.error(`${bin} not found!`)
+        process.exit(1)
+      } else {
+        throw e
+      }
+    }
+  }
+  return elmBin
+}
+
+const installElmPackage = () => {
+  execElmBinInBenchDir('elm-package', ['install', '--yes'])
+}
+
+const execElmBinInBenchDir = (bin, args) => {
+  cmd = [elmBinPath(bin), ...args].join(' ')
+  if (!fs.existsSync(benchDir)) {
+    console.error('Missing benchmarks/ directory. Run `elm-benchmark init` first.')
+    process.exit(1)
+  }
+  proc.execSync(cmd, {
+    stdio: 'inherit',
+    cwd: benchDir,
+  })
+}
+
+const stubAppFile = `module Benchmarks exposing (main)
+
+import Benchmark exposing (..)
+import Benchmark.Runner exposing (BenchmarkProgram, program)
+
+
+sampleSuite : Benchmark
+sampleSuite =
+    let
+        longString =
+            String.repeat 100 "abcdefgh"
+
+        mapper char =
+            case char of
+                'd' ->
+                    'D'
+
+                _ ->
+                    char
+    in
+        describe "Sample benchmark"
+            [ describe "String.map"
+                [ benchmark "replace characters in a long string" <|
+                    \\_ -> String.map mapper longString
+                ]
+            ]
+
+
+main : BenchmarkProgram
+main =
+    program sampleSuite
+`
+
+const benchAppFile = path.join(benchDir, 'Benchmarks.elm')
+
+const init = () => {
+  ensureBenchDir()
+  prepareElmPackageJson()
+  installElmPackage()
+  ensureFile(benchAppFile, stubAppFile)
+  console.log('Done initializing!')
+}
+
+const defaultCompileTarget = 'docs/index.html'
+
+const compileTarget = () => {
+  const args = process.argv.slice(1)
+  if (args.length >= 3) {
+    return args[2]
+  } else {
+    return defaultCompileTarget
+  }
+}
+
+const compile = () => {
+  execElmBinInBenchDir('elm-make', [benchAppFile, '--yes', '--output', path.resolve(compileTarget())])
+}
+
+const help = () => {
+  console.log(`elm-benchmark [init|install|compile|help] [compileOutputFile]
+
+  - init    : Prepares benchmarks/ directory and install packages.
+  - install : Only installs packages specified in benchmarks/${elmPackageJson}.
+  - compile : Compiles benchmarks/Benchmarks.elm into \`compileOutputFile\`.
+              \`compileOutputFile\` defaults to ${defaultCompileTarget}
+  - help    : Prints this help.
+  `)
+  process.exit(1)
+}
+
+const mode = () => {
+  const args = process.argv.slice(1)
+  var mode = 'help'
+  if (args.length >= 2) {
+    if (args[1] == 'install') {
+      mode = 'install'
+    } else if (args[1] == 'init') {
+      mode = 'init'
+    } else if (args[1] == 'compile') {
+      mode = 'compile'
+    }
+  }
+  return mode
+}
+
+const main = () => {
+  switch (mode()) {
+    case 'help':
+      help()
+      break
+    case 'init':
+      init()
+      break
+    case 'install':
+      installElmPackage()
+      break
+    case 'compile':
+      compile()
+      break
+    default:
+      help()
+  }
+}
+
+main()

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "elm-benchmark",
   "version": "2.0.1",
-  "description": "Bootstrap BrianHicks/elm-benchmark in your project",
+  "description": "A CLI tool to manage BrianHicks/elm-benchmark in your Elm project",
   "engines": {
     "node": ">=6"
   },

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "elm-benchmark",
+  "version": "2.0.1",
+  "description": "Bootstrap BrianHicks/elm-benchmark in your project",
+  "engines": {
+    "node": ">=6"
+  },
+  "main": "elm-benchmark.js",
+  "bin": {
+    "elm-benchmark": "bin/elm-benchmark"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/BrianHicks/elm-benchmark.git"
+  },
+  "keywords": [
+    "elm",
+    "benchmark"
+  ],
+  "author": "BrianHicks",
+  "license": "BSD-3-Clause",
+  "bugs": {
+    "url": "https://github.com/BrianHicks/elm-benchmark/issues"
+  },
+  "homepage": "https://github.com/BrianHicks/elm-benchmark#readme",
+  "dependencies": {
+    "which": "^1.3.0"
+  }
+}


### PR DESCRIPTION
As discussed in #38, merging [ymtszw/elm-benchmark-helper](https://github.com/ymtszw/elm-benchmark-helper) into upstream.

Some additional info: I tested npm packaging for a bit and found that `pack`-then-`publish` method can handle a package that resides in subdirectory just fine (seemingly. Not actually published ofc).
I put `make` phony for that, though if it isn't required please just say so :)