### PR TITLE
Fix Quick Start example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Here's a sample, benchmarking [`Array.Hamt`](http://package.elm-lang.org/package
 
 ```elm
 import Array
-import Arry.Hamt
+import Arry.Hamt as Hamt
 import Benchmark exposing (..)
 
 


### PR DESCRIPTION
It has `import Array.Hamt` but should be `import Array.Hamt as Hamt` - the examples in the file are things like `Hamt.slice 50 100 sampleArray` 😄 